### PR TITLE
LSimVar update and kill logic change

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Core systems implementation for flybywire_A32NX as wasm module.
 
 ## Steps to add new system
 - Create all your system implementation(as classes) in its own header file with a master class so that you don't flood `wasm_sys.cpp`
-  - Expose only `init()`, `update()` and `updateSimVars()`.
-  - Create a class instance under `wasm_sys.h`, WasmSys master class(qualified as private and not public) and call your system's init, update and updateSimVars function within the wasmSys class's public `init()` and `update()` function declarations.
+  - Expose only `init()`, `update()`, (NOTE: `updateSimVars()` has been removed)
+  - Create a class instance under `wasm_sys.h`, WasmSys master class(qualified as private and not public) and call your system's `init()`, `update()` function within the wasmSys class's public `init()` and `update()` function declarations.
     - currently implemented as wasm_guage, moving forward it'll be ported to wasm in-process module. You don't have to worry about porting anything/changing anything, it'll be a single function call update.
     - Current implementation uses wasm module run absTime to calulate _deltaTime instead of directly using deltaTime from pData structure, this is done keeping the above
       point under consideration, since _deltaTime is bound to gauge refresh rate.(Note: currently the difference between currentAbsTime and lastAbsTime will be equal to            REFRESH_RATE defined under common_sys.h)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Core systems implementation for flybywire_A32NX as wasm module.
 ## Steps to add new system
 - Create all your system implementation(as classes) in its own header file with a master class so that you don't flood `wasm_sys.cpp`
   - Expose only `init()`, `update()` and `updateSimVars()`.
-  - Create a class instance under `wasm_sys.cpp`, wasy_sys master clas(qualified as private and not public) and call your system's init, update and updateSimVars function within the wasmSys class's public `init()` and `update()` function declarations.
+  - Create a class instance under `wasm_sys.h`, wasy_sys master class(qualified as private and not public) and call your system's init, update and updateSimVars function within the wasmSys class's public `init()` and `update()` function declarations.
     - currently implemented as wasm_guage, moving forward it'll be ported to wasm in-process module. You don't have to worry about porting anything/changing anything, it'll be a single function call update.
     - Current implementation uses wasm module run absTime to calulate _deltaTime instead of directly using deltaTime from pData structure, this is done keeping the above
       point under consideration, since _deltaTime is bound to gauge refresh rate.(Note: currently the difference between currentAbsTime and lastAbsTime will be equal to            REFRESH_RATE defined under common_sys.h)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Core systems implementation for flybywire_A32NX as wasm module.
 ## Steps to add new system
 - Create all your system implementation(as classes) in its own header file with a master class so that you don't flood `wasm_sys.cpp`
   - Expose only `init()`, `update()` and `updateSimVars()`.
-  - Create a class instance under `wasm_sys.h`, wasy_sys master class(qualified as private and not public) and call your system's init, update and updateSimVars function within the wasmSys class's public `init()` and `update()` function declarations.
+  - Create a class instance under `wasm_sys.h`, WasmSys master class(qualified as private and not public) and call your system's init, update and updateSimVars function within the wasmSys class's public `init()` and `update()` function declarations.
     - currently implemented as wasm_guage, moving forward it'll be ported to wasm in-process module. You don't have to worry about porting anything/changing anything, it'll be a single function call update.
     - Current implementation uses wasm module run absTime to calulate _deltaTime instead of directly using deltaTime from pData structure, this is done keeping the above
       point under consideration, since _deltaTime is bound to gauge refresh rate.(Note: currently the difference between currentAbsTime and lastAbsTime will be equal to            REFRESH_RATE defined under common_sys.h)

--- a/data/data.h
+++ b/data/data.h
@@ -13,7 +13,7 @@
 */
 void initUnitEnums();
 void initLocalSimVarsIDs();
-void updateLocalSimVars();
+void updateLSimVars();
 void updateASimVars();
 
 ENUM* ENUM_UNITS;
@@ -40,7 +40,7 @@ void initLocalSimVarsIDs() {
         ID_LSIMVAR[i] = register_named_variable(pcstring_lSimVars[i]);
     }
 }
-void updateLocalSimVars() {
+void updateLSimVars() {
     //check for dirtyLVars
     for (int i = 0; i < totalLVarsCount; i++) {
         if (lastLVarsValue[i] != lSimVarsValue[i]) {

--- a/systems/bleed_sys.h
+++ b/systems/bleed_sys.h
@@ -15,11 +15,6 @@ public:
     void update(const double currentAbsTime) {
         //TODO
     }
-    void updateSimVars() {
-        for (int i = ENG1_BLEED_PRESSURE; i <= ENG2_BLEED_TEMPERATURE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 class APUBleed {
@@ -33,11 +28,6 @@ public:
     void update(const double currentAbsTime) {
         //TODO
     }
-    void updateSimVars() {
-        for (int i = APU_BLEED_PRESSURE; i <= APU_BLEED_TEMPERATURE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 class GPUBleed {
@@ -50,11 +40,6 @@ public:
     }
     void update(const double currentAbsTime) {
         //TODO
-    }
-    void updateSimVars() {
-        for (int i = GPU_BLEED_PRESSURE; i <= GPU_BLEED_TEMPERATURE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
     }
 };
 
@@ -213,11 +198,6 @@ public:
             lSimVarsValue[X_BLEED_VALVE] = 0;
         }
     }
-    void updateSimVars() {
-        for (int i = ENG1_IP_VALVE; i <= X_BLEED_VALVE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 class Ducts {
@@ -323,11 +303,6 @@ public:
             execute_calculator_code("0 (&gt;K:APU_BLEED_AIR_SOURCE_TOGGLE)", nullptr, nullptr, nullptr);            //all bleed starter engines require APU_BLEED SOURCE internally
         }
     }
-    void updateSimVars() {
-        for (int i = DUCT1; i <= DUCT2_PRESSURE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
  
 class BleedSys {
@@ -352,13 +327,6 @@ public:
         valveUnit.update(currentAbsTime);
         ductUnit.update(currentAbsTime);
 
-    }
-    void updateSimVars() {
-        engUnit.updateSimVars();
-        apuUnit.updateSimVars();
-        gpuUnit.updateSimVars();
-        valveUnit.updateSimVars();
-        ductUnit.updateSimVars();
     }
 };
 

--- a/systems/elec_sys.h
+++ b/systems/elec_sys.h
@@ -119,12 +119,6 @@ public:
         else {
             BATDischarging(currentAbsTime);
         }
-        updateSimVars();
-    }
-    void updateSimVars() {
-        for (int i = BATT1_ONLINE; i <= BATT2_AMPERAGE; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
     }
 };
 
@@ -152,11 +146,6 @@ public:
             lSimVarsValue[EXT_GEN_VOLTAGE] = 0;
             lSimVarsValue[EXT_GEN_AMPERAGE] = 0;
             lSimVarsValue[EXT_GEN_FREQ] = 0;
-        }
-    }
-    void updateSimVars() {
-        for (int i = EXT_GEN_VOLTAGE; i <= EXT_GEN_FREQ; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
         }
     }
 };
@@ -191,11 +180,6 @@ public:
             lSimVarsValue[APU_GEN_FREQ] = 0;
         }
 
-    }
-    void updateSimVars() {
-        for (int i = APU_GEN_ONLINE; i <= APU_LOAD_PERCENT; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
     }
 };
 
@@ -297,11 +281,6 @@ public:
         updateGen1(currentAbsTime, ambient);
         updateGen2(currentAbsTime, ambient);
     }
-    void updateSimVars() {
-        for (int i = GEN1_ONLINE; i <= GEN2_IDG; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 /*
@@ -337,11 +316,6 @@ public:
                 lSimVarsValue[EMER_AMPERAGE] = 0; //15kVA RAT
                 lSimVarsValue[EMER_FREQ] = 0;
             }
-        }
-    }
-    void updateSimVars() {
-        for (int i = EMER_ONLINE; i <= EMER_FREQ; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
         }
     }
 };
@@ -510,11 +484,6 @@ public:
         updateACBuses();
         updateDCBuses();
     }
-    void updateSimVars() {
-        for (int i = AC_BUS1; i <= HOT_BUS2; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 /*
@@ -610,11 +579,6 @@ public:
         updateTRESS();
         updateSTATINV();
     }
-    void updateSimVars() {
-        for (int i = TR1_ONLINE; i <= STATICINV_FREQ; i++) {
-            set_named_variable_value(ID_LSIMVAR[i],lSimVarsValue[i]);
-        }
-    }
 };
 
 class Circuit{
@@ -688,11 +652,6 @@ public:
         updateCircuitBreakers();
         updateCircuits();
     }
-    void updateSimVars() {
-        for (int i = CIRCUIT_1XP; i <= CIRCUIT_704PP; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 /*
@@ -733,16 +692,6 @@ public:
         busUnit.update(currentAbsTime);
         convertorUnit.update(currentAbsTime);
         circuitUnit.update();
-    }
-    void updateSimVars() {
-        battUnit.updateSimVars();
-        gpuUnit.updateSimVars();
-        apuUnit.updateSimVars();
-        engUnit.updateSimVars();
-        emerUnit.updateSimVars();
-        busUnit.updateSimVars();
-        convertorUnit.updateSimVars();
-        circuitUnit.updateSimVars();
     }
 };
 //TODO

--- a/systems/eng_sys.h
+++ b/systems/eng_sys.h
@@ -14,9 +14,6 @@ public:
     void update() {
 
     }
-    void updateSimVars() {
-
-    }
 };
 
 class APUEngine {
@@ -134,11 +131,6 @@ public:
         }
         updateEGTWarn();
     }
-    void updateSimVars() {
-        for (int i = APU_FLAP_OPEN; i <= APU_EGT_WARN; i++) {
-            set_named_variable_value(ID_LSIMVAR[i], lSimVarsValue[i]);
-        }
-    }
 };
 
 class EngSys {
@@ -156,11 +148,6 @@ class EngSys {
         eng1.update();
         eng2.update();
         apuEng.update(currentAbsTime);
-    }
-    void updateSimVars() {
-        eng1.updateSimVars();
-        eng2.updateSimVars();
-        apuEng.updateSimVars();
     }
 };
 

--- a/systems/packs_sys.h
+++ b/systems/packs_sys.h
@@ -11,9 +11,6 @@ public:
     void update() {
 
     }
-    void updateSimVars() {
-
-    }
 };
 
 class Cabin {
@@ -23,9 +20,6 @@ public:
 
     }
     void update() {
-
-    }
-    void updateSimVars() {
 
     }
 };
@@ -43,9 +37,5 @@ public:
     void update() {
         packsUnit.update();
         cabinUnit.update();
-    }
-    void updateSimVars() {
-        packsUnit.updateSimVars();
-        cabinUnit.updateSimVars();
     }
 };

--- a/systems/press_sys.h
+++ b/systems/press_sys.h
@@ -11,7 +11,4 @@ public:
     void update() {
 
     }
-    void updateSimVars() {
-
-    }
 };

--- a/wasm_sys.cpp
+++ b/wasm_sys.cpp
@@ -25,23 +25,19 @@ extern "C" {
                 initialized = true;
                 debug_print("WASM_SYS initialized");
             }
-        } else {
+        } else if (!kill){
             const double lastRefresh = currentAbsTime - lastAbsTime;
             #ifdef DEBUG
             printf("WASM_SYS waiting till %fms to update\n", REFRESH_RATE - lastRefresh);
             #endif
             if (lastRefresh >= REFRESH_RATE) {
-
                 debug_print("WASM_SYS now updating...");
-
                 //service.handleSimDispatch();
                 WASM_SYS.update(currentAbsTime);
-
                 debug_print("WASM_SYS update completed.");
-
             }
         }
-        kill = service.simStopCheck();
+        kill = service.simStopCheck(service_id);
         if (kill) {
             debug_print("Service handle received KILL trigger...");
             WASM_SYS.destroy();

--- a/wasm_sys.h
+++ b/wasm_sys.h
@@ -12,6 +12,8 @@
 #	define __attribute__(x)
 #	define __restrict__
 #endif*/
+#include "common_sys.h"
+
 #include "systems/elec_sys.h"
 #include "systems/packs_sys.h"
 #include "systems/bleed_sys.h"
@@ -46,7 +48,7 @@ public:
         PRESS_SYSTEM.update();
         ENG_SYSTEM.update(currentAbsTime);
 
-        updateLocalSimVars();
+        updateLSimVars();
 
         lastAbsTime = currentAbsTime;
     }

--- a/wasm_sys.h
+++ b/wasm_sys.h
@@ -46,11 +46,7 @@ public:
         PRESS_SYSTEM.update();
         ENG_SYSTEM.update(currentAbsTime);
 
-        ELEC_SYSTEM.updateSimVars();
-        PACK_SYSTEM.updateSimVars();
-        BLEED_SYSTEM.updateSimVars();
-        PRESS_SYSTEM.updateSimVars();
-        ENG_SYSTEM.updateSimVars();
+        updateLocalSimVars();
 
         lastAbsTime = currentAbsTime;
     }


### PR DESCRIPTION
This PR adds/fixes the following:
- eventID mismatch for 3rd party interaction
- update readme
- updateSimVars() no longer needed locally, instead now uses a global sim var update call with dirty value tracking
